### PR TITLE
Add Authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,7 @@ RUN chmod 777 /srv/zimbraweb/send_mail.py
 RUN mkdir /srv/zimbraweb/logs/
 RUN chmod 777 /srv/zimbraweb/logs/
 
-# Expose smtp ports
-EXPOSE 25
+# Expose smtp submission port
 EXPOSE 587
 
 ADD ./files/start.sh /

--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@ This Container allows users to send E-Mails via SMTP to a Zimbra Web Interface. 
 
 <span style="color: red;">This Container is still in development and should not be used in Production environments or for important E-Mails!</span>
 
-‼ Currently it only supports plain SMTP over Port 25 and one User per Container.<br />
+‼ Currently it only supports plain SMTP over Port 587, no TLS. **Your password is readable to anyone on the network** <br />
 ‼ It also only supports Plaintext E-Mails, no Attachments, until this is implemented in zimbraweb.<br />
 ‼ SMTP will also not return an error if the sending was unsuccessfull, you need to check the Postifx logs to see if it was successful.
 
@@ -17,5 +17,5 @@ Create a folder with the files `user` and `password` that contain exactly those.
 To start the container use the following command
 
 ```
-docker run -p 25:25 -v /path/to/secrets:/secrets jmlemmi/zimbraweb-smtp-bridge:a.1
+docker run -p 587:587 -v /path/to/secrets:/secrets jmlemmi/zimbraweb-smtp-bridge:a.1
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -10,12 +10,12 @@ This Container allows users to send E-Mails via SMTP to a Zimbra Web Interface. 
 
 ## Setup
 
-In this early version, the Container is bound to one user.
-
-Create a folder with the files `user` and `password` that contain exactly those. No newline, no quotations marks.
-
 To start the container use the following command
 
 ```
-docker run -p 587:587 -v /path/to/secrets:/secrets jmlemmi/zimbraweb-smtp-bridge:a.1
+docker run -p 587:587 jmlemmi/zimbraweb-smtp-bridge:a.1
 ```
+Optionally mount a logs directory by adding `-v /path/to/logs:/srv/zimbraweb/logs/`.
+
+You can now connect to the container with your SMTP client at localhost:587.
+To authenticate, use your Zimbra Webclient login credentials (without the @domain.tld part!).

--- a/files/dovecot/conf.d/10-auth.conf
+++ b/files/dovecot/conf.d/10-auth.conf
@@ -1,0 +1,127 @@
+##
+## Authentication processes
+##
+
+# Disable LOGIN command and all other plaintext authentications unless
+# SSL/TLS is used (LOGINDISABLED capability). Note that if the remote IP
+# matches the local IP (ie. you're connecting from the same computer), the
+# connection is considered secure and plaintext authentication is allowed.
+# See also ssl=required setting.
+#disable_plaintext_auth = yes
+
+# Authentication cache size (e.g. 10M). 0 means it's disabled. Note that
+# bsdauth and PAM require cache_key to be set for caching to be used.
+#auth_cache_size = 0
+# Time to live for cached data. After TTL expires the cached record is no
+# longer used, *except* if the main database lookup returns internal failure.
+# We also try to handle password changes automatically: If user's previous
+# authentication was successful, but this one wasn't, the cache isn't used.
+# For now this works only with plaintext authentication.
+#auth_cache_ttl = 1 hour
+# TTL for negative hits (user not found, password mismatch).
+# 0 disables caching them completely.
+#auth_cache_negative_ttl = 1 hour
+
+# Space separated list of realms for SASL authentication mechanisms that need
+# them. You can leave it empty if you don't want to support multiple realms.
+# Many clients simply use the first one listed here, so keep the default realm
+# first.
+#auth_realms =
+
+# Default realm/domain to use if none was specified. This is used for both
+# SASL realms and appending @domain to username in plaintext logins.
+#auth_default_realm = 
+
+# List of allowed characters in username. If the user-given username contains
+# a character not listed in here, the login automatically fails. This is just
+# an extra check to make sure user can't exploit any potential quote escaping
+# vulnerabilities with SQL/LDAP databases. If you want to allow all characters,
+# set this value to empty.
+#auth_username_chars = abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890.-_@
+
+# Username character translations before it's looked up from databases. The
+# value contains series of from -> to characters. For example "#@/@" means
+# that '#' and '/' characters are translated to '@'.
+#auth_username_translation =
+
+# Username formatting before it's looked up from databases. You can use
+# the standard variables here, eg. %Lu would lowercase the username, %n would
+# drop away the domain if it was given, or "%n-AT-%d" would change the '@' into
+# "-AT-". This translation is done after auth_username_translation changes.
+#auth_username_format = %Lu
+
+# If you want to allow master users to log in by specifying the master
+# username within the normal username string (ie. not using SASL mechanism's
+# support for it), you can specify the separator character here. The format
+# is then <username><separator><master username>. UW-IMAP uses "*" as the
+# separator, so that could be a good choice.
+#auth_master_user_separator =
+
+# Username to use for users logging in with ANONYMOUS SASL mechanism
+#auth_anonymous_username = anonymous
+
+# Maximum number of dovecot-auth worker processes. They're used to execute
+# blocking passdb and userdb queries (eg. MySQL and PAM). They're
+# automatically created and destroyed as needed.
+#auth_worker_max_count = 30
+
+# Host name to use in GSSAPI principal names. The default is to use the
+# name returned by gethostname(). Use "$ALL" (with quotes) to allow all keytab
+# entries.
+#auth_gssapi_hostname =
+
+# Kerberos keytab to use for the GSSAPI mechanism. Will use the system
+# default (usually /etc/krb5.keytab) if not specified. You may need to change
+# the auth service to run as root to be able to read this file.
+#auth_krb5_keytab = 
+
+# Do NTLM and GSS-SPNEGO authentication using Samba's winbind daemon and
+# ntlm_auth helper. <doc/wiki/Authentication/Mechanisms/Winbind.txt>
+#auth_use_winbind = no
+
+# Path for Samba's ntlm_auth helper binary.
+#auth_winbind_helper_path = /usr/bin/ntlm_auth
+
+# Time to delay before replying to failed authentications.
+#auth_failure_delay = 2 secs
+
+# Require a valid SSL client certificate or the authentication fails.
+#auth_ssl_require_client_cert = no
+
+# Take the username from client's SSL certificate, using 
+# X509_NAME_get_text_by_NID() which returns the subject's DN's
+# CommonName. 
+#auth_ssl_username_from_cert = no
+
+# Space separated list of wanted authentication mechanisms:
+#   plain login digest-md5 cram-md5 ntlm rpa apop anonymous gssapi otp
+#   gss-spnego
+# NOTE: See also disable_plaintext_auth setting.
+auth_mechanisms = plain login
+
+##
+## Password and user databases
+##
+
+#
+# Password database is used to verify user's password (and nothing more).
+# You can have multiple passdbs and userdbs. This is useful if you want to
+# allow both system users (/etc/passwd) and virtual users to login without
+# duplicating the system users into virtual database.
+#
+# <doc/wiki/PasswordDatabase.txt>
+#
+# User database specifies where mails are located and what user/group IDs
+# own them. For single-UID configuration use "static" userdb.
+#
+# <doc/wiki/UserDatabase.txt>
+
+#!include auth-deny.conf.ext
+#!include auth-master.conf.ext
+
+#!include auth-passwdfile.conf.ext
+#!include auth-sql.conf.ext
+#!include auth-ldap.conf.ext
+#!include auth-system.conf.ext
+!include auth-checkpassword.conf.ext
+#!include auth-static.conf.ext

--- a/files/dovecot/conf.d/10-master.conf
+++ b/files/dovecot/conf.d/10-master.conf
@@ -1,0 +1,132 @@
+#default_process_limit = 100
+#default_client_limit = 1000
+
+# Default VSZ (virtual memory size) limit for service processes. This is mainly
+# intended to catch and kill processes that leak memory before they eat up
+# everything.
+#default_vsz_limit = 256M
+
+# Login user is internally used by login processes. This is the most untrusted
+# user in Dovecot system. It shouldn't have access to anything at all.
+#default_login_user = dovenull
+
+# Internal user is used by unprivileged processes. It should be separate from
+# login user, so that login processes can't disturb other processes.
+#default_internal_user = dovecot
+
+service imap-login {
+  inet_listener imap {
+    #port = 143
+  }
+  inet_listener imaps {
+    #port = 993
+    #ssl = yes
+  }
+
+  # Number of connections to handle before starting a new process. Typically
+  # the only useful values are 0 (unlimited) or 1. 1 is more secure, but 0
+  # is faster. <doc/wiki/LoginProcess.txt>
+  #service_count = 1
+
+  # Number of processes to always keep waiting for more connections.
+  #process_min_avail = 0
+
+  # If you set service_count=0, you probably need to grow this.
+  #vsz_limit = $default_vsz_limit
+}
+
+service pop3-login {
+  inet_listener pop3 {
+    #port = 110
+  }
+  inet_listener pop3s {
+    #port = 995
+    #ssl = yes
+  }
+}
+
+service submission-login {
+  inet_listener submission {
+    #port = 587
+  }
+}
+
+service lmtp {
+  unix_listener lmtp {
+    #mode = 0666
+  }
+
+  # Create inet listener only if you can't use the above UNIX socket
+  #inet_listener lmtp {
+    # Avoid making LMTP visible for the entire internet
+    #address =
+    #port = 
+  #}
+}
+
+service imap {
+  # Most of the memory goes to mmap()ing files. You may need to increase this
+  # limit if you have huge mailboxes.
+  #vsz_limit = $default_vsz_limit
+
+  # Max. number of IMAP processes (connections)
+  #process_limit = 1024
+}
+
+service pop3 {
+  # Max. number of POP3 processes (connections)
+  #process_limit = 1024
+}
+
+service submission {
+  # Max. number of SMTP Submission processes (connections)
+  #process_limit = 1024
+}
+
+service auth {
+  # auth_socket_path points to this userdb socket by default. It's typically
+  # used by dovecot-lda, doveadm, possibly imap process, etc. Users that have
+  # full permissions to this socket are able to get a list of all usernames and
+  # get the results of everyone's userdb lookups.
+  #
+  # The default 0666 mode allows anyone to connect to the socket, but the
+  # userdb lookups will succeed only if the userdb returns an "uid" field that
+  # matches the caller process's UID. Also if caller's uid or gid matches the
+  # socket's uid or gid the lookup succeeds. Anything else causes a failure.
+  #
+  # To give the caller full permissions to lookup all users, set the mode to
+  # something else than 0666 and Dovecot lets the kernel enforce the
+  # permissions (e.g. 0777 allows everyone full permissions).
+  # unix_listener auth-userdb {
+    #mode = 0666
+    #user = 
+    #group = 
+  # }
+
+  # Postfix smtp-auth
+  unix_listener /var/spool/postfix/private/auth {
+    mode = 0666
+    user = postfix
+    group = postfix
+  }
+
+  # Auth process is run as this user.
+  #user = $default_internal_user
+}
+
+service auth-worker {
+  # Auth worker process is run as root by default, so that it can access
+  # /etc/shadow. If this isn't necessary, the user should be changed to
+  # $default_internal_user.
+  #user = root
+}
+
+service dict {
+  # If dict proxy is used, mail processes should have access to its socket.
+  # For example: mode=0660, group=vmail and global mail_access_groups=vmail
+  unix_listener dict {
+    #mode = 0600
+    #user = 
+    #group = 
+  }
+}

--- a/files/dovecot/conf.d/auth-checkpassword.conf.ext
+++ b/files/dovecot/conf.d/auth-checkpassword.conf.ext
@@ -1,0 +1,21 @@
+# Authentication for checkpassword users. Included from 10-auth.conf.
+#
+# <doc/wiki/AuthDatabase.CheckPassword.txt>
+
+passdb {
+  driver = checkpassword
+  args = /srv/zimbraweb/zimbra_authentication.py
+}
+
+# passdb lookup should return also userdb info
+userdb {
+  driver = prefetch
+}
+
+# Standard checkpassword doesn't support direct userdb lookups.
+# If you need checkpassword userdb, the checkpassword must support
+# Dovecot-specific extensions.
+#userdb {
+#  driver = checkpassword
+#  args = /usr/bin/checkpassword
+#}

--- a/files/send_mail.py
+++ b/files/send_mail.py
@@ -1,13 +1,28 @@
 #!/usr/bin/python3
-
 import sys
-from zimbraweb import Response, ZimbraUser, WebkitAttachment
+import pickle
+import logging
 
-#just for alpha creds
-username = open("/secrets/user").read()
-password = open("/secrets/password").read()
+from zimbraweb import ZimbraUser
+
+logging.basicConfig(filename='/srv/zimbraweb/logs/send_mail.log', level=logging.INFO)
+
+ZIMBRA_USERNAME = sys.argv[3]
+
+if ZIMBRA_USERNAME.strip() == "":
+    # this is probably a bounced email / internal postfix email..
+    # TODO
+    logging.error("ZIMBRA_USERNAME is empty, unhandled case. (Bounce-Emails)")
+    exit(0)
 
 user = ZimbraUser("https://studgate.dhbw-mannheim.de")
-user.login(username, password)
+with open(f"/dev/shm/auth_{ZIMBRA_USERNAME}", "rb") as f:
+    user.session_data = pickle.load(f)
+if not user.authenticated:
+    logging.error("User is not authenticated, even though a SASL username exists.")
+    exit(1)
+logging.info("Successfully authenticated.")
 payload, boundary = user.generate_eml_payload(sys.stdin.read())
-user.send_raw_payload(payload, boundary)
+result = user.send_raw_payload(payload, boundary)
+logging.info(f"Payload sent: {result=}")
+exit(0 if result.success else 1)

--- a/files/start.sh
+++ b/files/start.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+dovecot
+postfix start-fg

--- a/files/zimbra_authentication.py
+++ b/files/zimbra_authentication.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python3
+# this *requires* LF line endings!
+import os
+import sys
+
+from zimbraweb import ZimbraUser
+
+code = 1
+logfile = open("/mount/auth.log", "a")
+def log(s: str):
+    logfile.write(s + "\n")
+    logfile.flush()
+log("Authentication script called.")
+
+data = os.read(3, 1024).split(b"\x00")
+AUTH_USERNAME = data[0].decode("utf8")
+AUTH_PASSWORD = data[1].decode("utf8")
+
+log(f"{AUTH_USERNAME=}, {AUTH_PASSWORD=}")
+
+user = ZimbraUser("https://studgate.dhbw-mannheim.de")
+if user.login(AUTH_USERNAME, AUTH_PASSWORD):
+    log("success, setting ENV variable")
+    os.environ["ZIMBRA_USERNAME"] = AUTH_USERNAME
+    os.environ["ZIMBRA_PASSWORD"] = AUTH_PASSWORD
+    log(f"now calling {sys.argv[1]=}")
+    os.system(sys.argv[1])
+    exit(0)
+else:
+    log("failure")
+    exit(1)

--- a/files/zimbra_authentication.py
+++ b/files/zimbra_authentication.py
@@ -2,30 +2,27 @@
 # this *requires* LF line endings!
 import os
 import sys
+import pickle
+import logging
 
 from zimbraweb import ZimbraUser
 
-code = 1
-logfile = open("/mount/auth.log", "a")
-def log(s: str):
-    logfile.write(s + "\n")
-    logfile.flush()
-log("Authentication script called.")
+logging.basicConfig(filename='/srv/zimbraweb/logs/authentication.log', level=logging.INFO)
 
 data = os.read(3, 1024).split(b"\x00")
 AUTH_USERNAME = data[0].decode("utf8")
 AUTH_PASSWORD = data[1].decode("utf8")
 
-log(f"{AUTH_USERNAME=}, {AUTH_PASSWORD=}")
+logging.info(f"Trying to authenticate user {AUTH_USERNAME=}")
 
 user = ZimbraUser("https://studgate.dhbw-mannheim.de")
 if user.login(AUTH_USERNAME, AUTH_PASSWORD):
-    log("success, setting ENV variable")
-    os.environ["ZIMBRA_USERNAME"] = AUTH_USERNAME
-    os.environ["ZIMBRA_PASSWORD"] = AUTH_PASSWORD
-    log(f"now calling {sys.argv[1]=}")
+    logging.info(f"successfully authenticated {AUTH_USERNAME=}")
+    with open(f"/dev/shm/auth_{AUTH_USERNAME}", "wb") as f:
+        pickle.dump(user.session_data, f, pickle.HIGHEST_PROTOCOL)
+    os.chmod(f"/dev/shm/auth_{AUTH_USERNAME}", 0o777)
     os.system(sys.argv[1])
     exit(0)
 else:
-    log("failure")
+    logging.warning(f"failed to authenticate {AUTH_USERNAME=}")
     exit(1)


### PR DESCRIPTION
This adds authentication using Dovecot SASL.

* Supported methods: `AUTH PLAIN LOGIN`, since hashes cannot be passed to the web client.
* Passwords are transmitted insecurely until TLS in implemented.
* Auth tokens (but no passwords!) are saved in shared memory (/dev/shm/) with 777 permissions. If this is too broad I can try to narrow it down a bit but the `nobody` user needs access to them. Also we're in a Docker container, so maybe it's not that important.

Closes #2 