### PR TITLE
Add configuration options.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,9 @@ RUN chmod 777 /srv/zimbraweb/*.py
 
 RUN mkdir /srv/zimbraweb/mnt/
 RUN chmod -R 777 /srv/zimbraweb/mnt/
-RUN mkdir /srv/zimbraweb/mnt/logs/
+
+RUN mkdir /srv/zimbraweb/logs/
+RUN chmod -R 777 /srv/zimbraweb/logs/
 
 VOLUME /srv/zimbraweb/mnt/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,9 +50,11 @@ ADD ./files/dovecot/conf.d/auth-checkpassword.conf.ext /etc/dovecot/conf.d/auth-
 ADD ./files/*.py /srv/zimbraweb/
 RUN chmod 777 /srv/zimbraweb/*.py
 
-# optionally mount this folder onto the host to get access to some log files, for debugging
-RUN mkdir /srv/zimbraweb/logs/
-RUN chmod 777 /srv/zimbraweb/logs/
+RUN mkdir /srv/zimbraweb/mnt/
+RUN chmod -R 777 /srv/zimbraweb/mnt/
+RUN mkdir /srv/zimbraweb/mnt/logs/
+
+VOLUME /srv/zimbraweb/mnt/
 
 # Expose smtp submission port
 EXPOSE 587

--- a/files/send_mail.py
+++ b/files/send_mail.py
@@ -11,7 +11,7 @@ from zimbra_config import get_config
 CONFIG = get_config()
 
 file_handler = logging.FileHandler(
-    filename='/srv/zimbraweb/mnt/logs/send_mail.log')
+    filename='/srv/zimbraweb/logs/send_mail.log')
 stdout_handler = logging.StreamHandler(sys.stdout)
 handlers = [file_handler, stdout_handler]
 

--- a/files/send_mail.py
+++ b/files/send_mail.py
@@ -8,7 +8,7 @@ from email.parser import Parser
 from zimbraweb import WebkitAttachment, ZimbraUser
 
 file_handler = logging.FileHandler(
-    filename='/srv/zimbraweb/logs/send_mail.log')
+    filename='/srv/zimbraweb/mnt/logs/send_mail.log')
 stdout_handler = logging.StreamHandler(sys.stdout)
 handlers = [file_handler, stdout_handler]
 
@@ -74,7 +74,7 @@ elif parsed["From"] == f'"Microsoft Outlook" <{ZIMBRA_USERNAME}@student.dhbw-man
     logging.info("Sending outlook test email via text/plain")
     user = get_auth_user(ZIMBRA_USERNAME)
     result = user.send_mail(to=parsed["To"], subject=parsed["Subject"],
-                   body="Diese E-Mail-Nachricht wurde von Microsoft Outlook automatisch während des Testens der Kontoeinstellungen gesendet.")
+                            body="Diese E-Mail-Nachricht wurde von Microsoft Outlook automatisch während des Testens der Kontoeinstellungen gesendet.")
     logging.info(f"Outlook test email sent: {result=}")
     exit(0 if result.success else 1)
 else:

--- a/files/start.sh
+++ b/files/start.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+python3 /srv/zimbraweb/zimbra_config.py
 dovecot
 postfix start
 python3 /srv/zimbraweb/zimbra_milter.py

--- a/files/zimbra_authentication.py
+++ b/files/zimbra_authentication.py
@@ -10,7 +10,7 @@ from zimbra_config import get_config
 
 CONFIG = get_config()
 
-logging.basicConfig(filename='/srv/zimbraweb/mnt/logs/authentication.log', level=logging.INFO)
+logging.basicConfig(filename='/srv/zimbraweb/logs/authentication.log', level=logging.INFO)
 
 data = os.read(3, 1024).split(b"\x00")
 AUTH_USERNAME = data[0].decode("utf8")

--- a/files/zimbra_authentication.py
+++ b/files/zimbra_authentication.py
@@ -6,20 +6,23 @@ import pickle
 import logging
 
 from zimbraweb import ZimbraUser
+from zimbra_config import get_config
+
+CONFIG = get_config()
 
 logging.basicConfig(filename='/srv/zimbraweb/mnt/logs/authentication.log', level=logging.INFO)
 
 data = os.read(3, 1024).split(b"\x00")
 AUTH_USERNAME = data[0].decode("utf8")
 
-if "@student.dhbw-mannheim.de" in AUTH_USERNAME:
-    AUTH_USERNAME = AUTH_USERNAME.replace("@student.dhbw-mannheim.de", "")
+if f"@{CONFIG['email_domain']}" in AUTH_USERNAME:
+    AUTH_USERNAME = AUTH_USERNAME.replace(f"@{CONFIG['email_domain']}", "")
 
 AUTH_PASSWORD = data[1].decode("utf8")
 
 logging.info(f"Trying to authenticate user {AUTH_USERNAME=}")
 
-user = ZimbraUser("https://studgate.dhbw-mannheim.de")
+user = ZimbraUser(CONFIG['zimbra_host'])
 if user.login(AUTH_USERNAME, AUTH_PASSWORD):
     logging.info(f"successfully authenticated {AUTH_USERNAME=}")
     with open(f"/dev/shm/auth_{AUTH_USERNAME}", "wb") as f:

--- a/files/zimbra_authentication.py
+++ b/files/zimbra_authentication.py
@@ -7,7 +7,7 @@ import logging
 
 from zimbraweb import ZimbraUser
 
-logging.basicConfig(filename='/srv/zimbraweb/logs/authentication.log', level=logging.INFO)
+logging.basicConfig(filename='/srv/zimbraweb/mnt/logs/authentication.log', level=logging.INFO)
 
 data = os.read(3, 1024).split(b"\x00")
 AUTH_USERNAME = data[0].decode("utf8")

--- a/files/zimbra_config.py
+++ b/files/zimbra_config.py
@@ -1,0 +1,75 @@
+import json
+from json.decoder import JSONDecodeError
+import os
+from typing import Dict
+import re
+
+CONF_PATH = "/srv/zimbraweb/mnt/config.json"
+
+def main():
+    if not os.path.isfile(CONF_PATH):
+        print("No config file found, creating.")
+        create_config()
+    while not validate_config():
+        ans = input("Current configuration seems invalid. Recreate (y/n)?")
+        while ans not in ["y", "n"]:
+            ans = input("Current configuration seems invalid. Recreate (y/n)?")
+        if ans == "y":
+            create_config()
+            return
+    return
+    
+def validate_config() -> bool:
+    with open(CONF_PATH, "r") as f:
+        try:
+            config = json.load(f)
+        except JSONDecodeError:
+            print("Corrupt config file. (Invalid JSON)")
+            return False
+    if not "zimbra_host" in config:
+        print("Missing zimbra_host parameter")
+        return False
+    host = re.match(r"https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)", config["zimbra_host"])
+    if not host:
+        print("Malformed zimbra_host. You need to include the protocol (http(s)://)!")
+
+    if not "email_domain" in config:
+        print("Missing email_domain parameter")
+        return False
+    
+    email_domain = re.match(r"(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]", config["email_domain"])
+    if not email_domain:
+        print("Malformed email_domain. Only include the part after the @ sign.")
+        return False
+    return True
+
+def create_config():
+    config = {
+        "zimbra_host": "https://studgate.dhbw-mannheim.de",
+        "email_domain": "student.dhbw-mannheim.de",
+    }
+
+    if os.isatty(0):
+        for key, default in config.items():
+            if default is not None:
+                config[key] = input(f"{key} (default: {default}): ") or default
+            else:
+                config[key] = input(f"{key} (default: {default}): ")
+    else:
+        print("not running interactively, assuming default values.")
+
+    with open(CONF_PATH, "w") as f:
+        json.dump(config, f, indent=4)
+
+    if not os.path.isdir("/srv/zimbraweb/mnt/logs"):
+        os.mkdir("/srv/zimbraweb/mnt/logs")
+        os.chmod("/srv/zimbraweb/mnt/logs", 0o777)
+    
+def get_config() -> Dict[str, str]:
+    validate_config()
+    with open(CONF_PATH, "r") as f:
+            config = json.load(f)
+    return config
+
+if __name__ == "__main__":
+    main()

--- a/files/zimbra_milter.py
+++ b/files/zimbra_milter.py
@@ -17,7 +17,7 @@ from Milter import milter
 from zimbraweb import emlparsing
 # syslog.openlog('milter')
 #
-file_handler = logging.FileHandler(filename='/srv/zimbraweb/mnts/logs/milter.log')
+file_handler = logging.FileHandler(filename='/srv/zimbraweb/mnt/logs/milter.log')
 stdout_handler = logging.StreamHandler(sys.stdout)
 handlers = [file_handler, stdout_handler]
 logging.basicConfig(handlers=handlers, level=logging.INFO)

--- a/files/zimbra_milter.py
+++ b/files/zimbra_milter.py
@@ -17,7 +17,7 @@ from Milter import milter
 from zimbraweb import emlparsing
 # syslog.openlog('milter')
 #
-file_handler = logging.FileHandler(filename='/srv/zimbraweb/mnt/logs/milter.log')
+file_handler = logging.FileHandler(filename='/srv/zimbraweb/logs/milter.log')
 stdout_handler = logging.StreamHandler(sys.stdout)
 handlers = [file_handler, stdout_handler]
 logging.basicConfig(handlers=handlers, level=logging.INFO)
@@ -46,9 +46,9 @@ class zimbraMilter(Milter.Milter):
         self.user = self.getsymval('{auth_authen}')
         self.auth_type = self.getsymval('{auth_type}')
         if self.user:
-            logging.info("user", self.user, "sent mail from", f, str)
+            logging.info(f"user {self.user} sent mail from {f}")
         else:
-            logging.warning("unauthenticated mail from", f, str)
+            logging.warning(f"unauthenticated mail from {f}")
             self.setreply("530", "5.7.0", "Authentication required")
             return Milter.REJECT
 

--- a/files/zimbra_milter.py
+++ b/files/zimbra_milter.py
@@ -9,26 +9,21 @@ import os
 from io import BytesIO
 import tempfile
 from time import strftime
+import logging
 
 import Milter
 from Milter import milter
 
 from zimbraweb import emlparsing
 # syslog.openlog('milter')
-
+#
+file_handler = logging.FileHandler(filename='/srv/zimbraweb/mnts/logs/milter.log')
+stdout_handler = logging.StreamHandler(sys.stdout)
+handlers = [file_handler, stdout_handler]
+logging.basicConfig(handlers=handlers, level=logging.INFO)
 
 class zimbraMilter(Milter.Milter):
     # https://github.com/sdgathman/pymilter/blob/master/sample.py
-
-    def log(self, *msg):
-        print("%s [%d]" % (strftime('%Y%b%d %H:%M:%S'), self.id), end=None)
-        for i in msg:
-            try:
-                print(i, end=None)
-            except UnicodeEncodeError:
-                s = i.encode(encoding='utf-8', errors='surrogateescape')
-                print(s, end=None)
-        print()
 
     def __init__(self):
         self.tempname = None
@@ -51,12 +46,12 @@ class zimbraMilter(Milter.Milter):
         self.user = self.getsymval('{auth_authen}')
         self.auth_type = self.getsymval('{auth_type}')
         if self.user:
-            self.log("user", self.user, "sent mail from", f, str)
+            logging.info("user", self.user, "sent mail from", f, str)
         else:
-            self.log("unauthenticated mail from", f, str)
+            logging.warning("unauthenticated mail from", f, str)
             self.setreply("530", "5.7.0", "Authentication required")
             return Milter.REJECT
-        
+
         return Milter.CONTINUE
 
     @Milter.decode('bytes')
@@ -64,7 +59,7 @@ class zimbraMilter(Milter.Milter):
         lname = name.lower()
         # log selected headers
         if lname in ('subject', 'x-mailer'):
-            self.log('%s: %s' % (name, val))
+            logging.debug('%s: %s' % (name, val))
         if self.fp:
             # add header to buffer
             self.fp.write(b"%s: %s\n" % (name.encode(), val))
@@ -112,7 +107,9 @@ class zimbraMilter(Milter.Milter):
             emlparsing.parse_eml(raw_eml)
         except emlparsing.UnsupportedEMLError:
             # Reply doesn't show up, not sure why :(
-            self.setreply("554", "5.7.1", "EML with html not supported! Use text/plain.")
+            logging.error("Unsupported EML.")
+            self.setreply("554", "5.7.1",
+                          "EML with html not supported! Use text/plain.")
             return Milter.REJECT
         return Milter.ACCEPT
 
@@ -125,7 +122,7 @@ class zimbraMilter(Milter.Milter):
         return Milter.CONTINUE
 
     def abort(self):
-        self.log("abort after %d body chars" % self.bodysize)
+        logging.debug("abort after %d body chars" % self.bodysize)
         return Milter.CONTINUE
 
 
@@ -180,10 +177,9 @@ def runmilter(name, socketname, timeout=0, rmsock=True):
     milter.opensocket(rmsock)
     start_seq = Milter._seq
 
-
     print("Changing chmod of socket to 777")
     os.chmod(socketname, 0o777)
-    
+
     try:
         milter.main()
     except milter.error:


### PR DESCRIPTION
* Log files have been moved to /srv/zimbraweb/mnt/logs/
* On startup of the container, a Python script looks in /srv/zimbraweb/mnt/config.json for a valid config file
   * A valid config file is found: continue as normal
   * An invalid or no config file is found:
      * If we're running interactively (`docker run -it ...`), ask stdin for config values
      * Otherwise, assume default values.

The docker container should be started like this, to preserve logs and the config file
```
$ docker run -v /my/local/folder/:/srv/zimbraweb/mnt -p 587:587 postfix:develop
```
Optionally run with `docker run -it -v ...` to configure interactively.