### PR TITLE
Add TLS support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,4 +62,7 @@ EXPOSE 587
 
 ADD ./files/start.sh /
 RUN chmod +x /start.sh
+
+ADD ./files/tls.sh /
+RUN chmod +x /tls.sh
 CMD ["/start.sh"]

--- a/Readme.md
+++ b/Readme.md
@@ -31,6 +31,8 @@ Follow the prompts. The certificate and key should end up in `/etc/letsencrypt/l
 
 ### Enabling TLS in the Container
 
+The following commands assume your Docker container is named `smtp_bride`. Substitute as necessary.
+
 Copy the certificate and key into the container:
 ```
 # docker cp /etc/letsencrypt/live/<your-server-domain>/fullchain.pem smtp_bridge:/srv/zimbraweb/ssl_certificate.pem

--- a/Readme.md
+++ b/Readme.md
@@ -13,8 +13,38 @@ This Container allows users to send E-Mails via SMTP to a Zimbra Web Interface. 
 To start the container use the following command
 
 ```
-docker run -p 587:587 ghcr.io/cirosec-studis/zimbraweb-smtp-bridge:nightly
+docker run --name smtp_bridge -p 587:587 ghcr.io/cirosec-studis/zimbraweb-smtp-bridge:nightly
 ```
+
+### TLS Support
+
+### Getting a certificate
+
+To enable TLS you first need to generate a certificate. You can do this on the host machine using [`certbot`](https://certbot.eff.org/), here's how to do it in Ubuntu:
+
+```bash
+$ sudo apt install certbot
+$ sudo certbot certonly --standalone -d <your-server-domain>
+```
+
+Follow the prompts. The certificate and key should end up in `/etc/letsencrypt/live/<your-server-domain>/fullchain.pem` and `/etc/letsencrypt/live/<your-server-domain>/privkey.pem`. 
+
+### Enabling TLS in the Container
+
+Copy the certificate and key into the container:
+```
+# docker cp /etc/letsencrypt/live/<your-server-domain>/fullchain.pem smtp_bridge:/srv/zimbraweb/ssl_certificate.pem
+# docker cp /etc/letsencrypt/live/<your-server-domain>/privkey.pem smtp_bridge:/srv/zimbraweb/private_key.pem
+```
+
+Enable TLS in the Container:
+```
+# docker run --it smtp_bridge /tls.sh
+```
+
+Follow the prompt again, you should be able accept the default values for the certificate and key location.
+
+That's it, TLS is now enabled! Use STARTTLS on port 2525.
 
 ### Docker Tags
 

--- a/files/tls.sh
+++ b/files/tls.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+echo "NOTE: none of these parameters are verified. If you screw something up, run the script again. If you want to remove TLS you need to reset the container."
+
+read -p 'What domain is this server running on? ' hostname
+
+read -p 'Where is the domain certificate located (within the docker container)? [default: /srv/zimbraweb/ssl_certificate.pem]: ' certfile
+certfile=${certfile:-/srv/zimbraweb/ssl_certificate.pem}
+
+read -p 'Where is the private key located (within the docker container)? [default: /srv/zimbraweb/private_key.pem]: ' keyfile
+keyfile=${keyfile:-/srv/zimbraweb/private_key.pem}
+
+chmod 777 ${keyfile}
+chmod 777 ${certfile}
+
+postconf -e myhostname=$hostname
+postconf -e "smtpd_tls_cert_file = ${certfile}"
+postconf -e "smtpd_tls_key_file = ${keyfile}"
+postconf -e 'smtp_tls_security_level = may'
+postconf -e 'smtpd_tls_security_level = may'
+postconf -e 'smtp_tls_note_starttls_offer = yes'
+postconf -e 'smtpd_tls_loglevel = 1'
+postconf -e 'smtpd_tls_received_header = yes'
+
+postfix stop
+postfix start


### PR DESCRIPTION
TLS can now be enabled by copying the certificate and private key into the container and running /tls.sh inside the container.

I chose to do it this way instead of adding a config item because this approach offers a bit more flexibility.

### TLS Support

### Getting a certificate

To enable TLS you first need to generate a certificate. You can do this on the host machine using [`certbot`](https://certbot.eff.org/), here's how to do it in Ubuntu:

```bash
$ sudo apt install certbot
$ sudo certbot certonly --standalone -d <your-server-domain>
```

Follow the prompts. The certificate and key should end up in `/etc/letsencrypt/live/<your-server-domain>/fullchain.pem` and `/etc/letsencrypt/live/<your-server-domain>/privkey.pem`. 

### Enabling TLS in the Container

The following commands assume your Docker container is named `smtp_bride`. Substitute as necessary.

Copy the certificate and key into the container:
```
# docker cp /etc/letsencrypt/live/<your-server-domain>/fullchain.pem smtp_bridge:/srv/zimbraweb/ssl_certificate.pem
# docker cp /etc/letsencrypt/live/<your-server-domain>/privkey.pem smtp_bridge:/srv/zimbraweb/private_key.pem
```

Enable TLS in the Container:
```
# docker run --it smtp_bridge /tls.sh
```

Follow the prompt again, you should be able accept the default values for the certificate and key location.

That's it, TLS is now enabled! Use STARTTLS on port 2525.