### PR TITLE
Add self-signed TLS by default.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,4 +65,6 @@ RUN chmod +x /start.sh
 
 ADD ./files/tls.sh /
 RUN chmod +x /tls.sh
+RUN mkdir /tls/
+
 CMD ["/start.sh"]

--- a/files/start.sh
+++ b/files/start.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 python3 /srv/zimbraweb/zimbra_config.py
+/tls.sh
 dovecot
 postfix start
 python3 /srv/zimbraweb/zimbra_milter.py


### PR DESCRIPTION
The container will now generate a TLS certificate (that's valid for 10 years) on startup.

To supply custom certificates, simply name the certificate `cert.pem` and the private key `key.pem` and put them in the same folder on the host.

Then start the container with the custom certificate:
```
docker run -v /host/path/to/tls/folder/:/tls/ --name smtp_bridge -h <your_domain_name> -p 587:587 ghcr.io/cirosec-studis/zimbraweb-smtp-bridge:nightly
```
