### PR TITLE
Clean Container Log (#41)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,11 @@ RUN postconf -e "mynetworks=0.0.0.0/0" "maillog_file=/var/log/log" "smtpd_sasl_p
 #RUN echo -e "postlog   unix-dgram n  -       n       -       1       postlogd" >> /etc/postfix/master.cf
 
 #postfix transport script execution
+RUN adduser --disabled-password posttransport
+RUN touch /var/log/log
+RUN chmod -R 777 /var/log/log
 RUN echo "*  zimbrawebtransport:" > /etc/postfix/transport
-RUN echo -e "zimbrawebtransport   unix  -       n       n       -       -       pipe\n  flags=FR user=nobody argv=/srv/zimbraweb/send_mail.py\n  \${nexthop} \${user} \${sasl_username}" >> /etc/postfix/master.cf
+RUN echo -e "zimbrawebtransport   unix  -       n       n       -       -       pipe\n  flags=FR user=posttransport argv=/srv/zimbraweb/send_mail.py\n  \${nexthop} \${user} \${sasl_username}" >> /etc/postfix/master.cf
 RUN postconf -e "transport_maps=texthash:/etc/postfix/transport"
 
 RUN echo -e "submission inet n - y - - smtpd\n -o syslog_name=postfix/submission\n -o smtpd_sasl_auth_enable=yes\n -o smtpd_sasl_path=private/auth\n -o smtpd_client_restrictions=permit_sasl_authenticated,reject" >> /etc/postfix/master.cf

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN pip3 install zimbraweb git+https://github.com/sdgathman/pymilter
 
 #postfix basic config
 RUN postconf -e "mynetworks=0.0.0.0/0" "maillog_file=/var/log/log" "smtpd_sasl_path=private/auth" "smtpd_sasl_type=dovecot" "smtpd_sasl_auth_enable=yes" "smtpd_delay_reject=yes" "smtpd_client_restrictions=permit_sasl_authenticated,reject" "smtpd_milters=unix:/milter.sock"
-#RUN echo -e "postlog   unix-dgram n  -       n       -       1       postlogd" >> /etc/postfix/master.cf
 
 #postfix transport script execution
 RUN adduser --disabled-password posttransport

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN pip3 install zimbraweb git+https://github.com/sdgathman/pymilter
 
 #postfix basic config
 RUN postconf -e "mynetworks=0.0.0.0/0" "maillog_file=/dev/stdout" "smtpd_sasl_path=private/auth" "smtpd_sasl_type=dovecot" "smtpd_sasl_auth_enable=yes" "smtpd_delay_reject=yes" "smtpd_client_restrictions=permit_sasl_authenticated,reject" "smtpd_milters=unix:/milter.sock"
+RUN echo -e "postlog   unix-dgram n  -       n       -       1       postlogd" >> /etc/postfix/master.cf
 
 #postfix transport script execution
 RUN echo "*  zimbrawebtransport:" > /etc/postfix/transport

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN python3 -m ensurepip; pip3 install --no-cache --upgrade pip setuptools
 RUN pip3 install zimbraweb git+https://github.com/sdgathman/pymilter
 
 #postfix basic config
-RUN postconf -e "mynetworks=0.0.0.0/0" "maillog_file=/var/log/maillog" "smtpd_sasl_path=private/auth" "smtpd_sasl_type=dovecot" "smtpd_sasl_auth_enable=yes" "smtpd_delay_reject=yes" "smtpd_client_restrictions=permit_sasl_authenticated,reject" "smtpd_milters=unix:/milter.sock"
+RUN postconf -e "mynetworks=0.0.0.0/0" "maillog_file=/var/log/log" "smtpd_sasl_path=private/auth" "smtpd_sasl_type=dovecot" "smtpd_sasl_auth_enable=yes" "smtpd_delay_reject=yes" "smtpd_client_restrictions=permit_sasl_authenticated,reject" "smtpd_milters=unix:/milter.sock"
 #RUN echo -e "postlog   unix-dgram n  -       n       -       1       postlogd" >> /etc/postfix/master.cf
 
 #postfix transport script execution

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN python3 -m ensurepip; pip3 install --no-cache --upgrade pip setuptools
 RUN pip3 install zimbraweb git+https://github.com/sdgathman/pymilter
 
 #postfix basic config
-RUN postconf -e "mynetworks=0.0.0.0/0" "maillog_file=/dev/stdout" "smtpd_sasl_path=private/auth" "smtpd_sasl_type=dovecot" "smtpd_sasl_auth_enable=yes" "smtpd_delay_reject=yes" "smtpd_client_restrictions=permit_sasl_authenticated,reject" "smtpd_milters=unix:/milter.sock"
-RUN echo -e "postlog   unix-dgram n  -       n       -       1       postlogd" >> /etc/postfix/master.cf
+RUN postconf -e "mynetworks=0.0.0.0/0" "maillog_file=/var/log/maillog" "smtpd_sasl_path=private/auth" "smtpd_sasl_type=dovecot" "smtpd_sasl_auth_enable=yes" "smtpd_delay_reject=yes" "smtpd_client_restrictions=permit_sasl_authenticated,reject" "smtpd_milters=unix:/milter.sock"
+#RUN echo -e "postlog   unix-dgram n  -       n       -       1       postlogd" >> /etc/postfix/master.cf
 
 #postfix transport script execution
 RUN echo "*  zimbrawebtransport:" > /etc/postfix/transport

--- a/files/hostnamefilter.py
+++ b/files/hostnamefilter.py
@@ -1,0 +1,7 @@
+import logging, platform
+
+class HostnameFilter(logging.Filter):
+    hostname = platform.node()
+    def filter(self, record):
+        record.hostname = HostnameFilter.hostname
+        return True

--- a/files/send_mail.py
+++ b/files/send_mail.py
@@ -11,11 +11,9 @@ from zimbra_config import get_config
 
 CONFIG = get_config()
 
-file_handler = logging.FileHandler(
-    filename='/srv/zimbraweb/logs/send_mail.log')
+#file_handler = logging.FileHandler(filename='/dev/stdout')
 stdout_handler = logging.StreamHandler(sys.stdout)
-handlers = [file_handler, stdout_handler]
-
+handlers = [stdout_handler]
 logging.basicConfig(handlers=handlers, level=logging.INFO)
 
 logging.info("send_mail started!")

--- a/files/send_mail.py
+++ b/files/send_mail.py
@@ -5,15 +5,24 @@ import pickle
 import logging
 from email.parser import Parser
 import smtplib
+import platform
 
 from zimbraweb import WebkitAttachment, ZimbraUser, emlparsing
 from zimbra_config import get_config
 
 CONFIG = get_config()
 
-#file_handler = logging.FileHandler(filename='/dev/stdout')
-stdout_handler = logging.StreamHandler(sys.stdout)
-handlers = [stdout_handler]
+#setting up logger
+class HostnameFilter(logging.Filter):
+    hostname = platform.node()
+    def filter(self, record):
+        record.hostname = HostnameFilter.hostname
+        return True
+handler = logging.FileHandler(filename='/var/log/python.log')
+#handler = logging.StreamHandler(sys.stdout)
+handler.addFilter(HostnameFilter())
+handler.setFormatter(logging.Formatter('%(asctime)s %(hostname)s python/%(filename)s: %(message)s', datefmt='%b %d %H:%M:%S'))
+handlers = [handler]
 logging.basicConfig(handlers=handlers, level=logging.INFO)
 
 logging.info("send_mail started!")

--- a/files/send_mail.py
+++ b/files/send_mail.py
@@ -5,27 +5,22 @@ import pickle
 import logging
 from email.parser import Parser
 import smtplib
-import platform
 
 from zimbraweb import WebkitAttachment, ZimbraUser, emlparsing
 from zimbra_config import get_config
 
-CONFIG = get_config()
-
 #setting up logger
-class HostnameFilter(logging.Filter):
-    hostname = platform.node()
-    def filter(self, record):
-        record.hostname = HostnameFilter.hostname
-        return True
-handler = logging.FileHandler(filename='/var/log/log')
-#handler = logging.StreamHandler(sys.stdout)
-handler.addFilter(HostnameFilter())
+import hostnamefilter
+#handler = logging.FileHandler(filename='/var/log/log')
+handler = logging.StreamHandler(sys.stdout)
+handler.addFilter(hostnamefilter.HostnameFilter())
 handler.setFormatter(logging.Formatter('%(asctime)s %(hostname)s python/%(filename)s: %(message)s', datefmt='%b %d %H:%M:%S'))
 handlers = [handler]
 logging.basicConfig(handlers=handlers, level=logging.INFO)
 
 logging.info("send_mail started!")
+
+CONFIG = get_config()
 
 ZIMBRA_USERNAME = sys.argv[3]
 

--- a/files/send_mail.py
+++ b/files/send_mail.py
@@ -18,7 +18,7 @@ class HostnameFilter(logging.Filter):
     def filter(self, record):
         record.hostname = HostnameFilter.hostname
         return True
-handler = logging.FileHandler(filename='/var/log/python.log')
+handler = logging.FileHandler(filename='/var/log/log')
 #handler = logging.StreamHandler(sys.stdout)
 handler.addFilter(HostnameFilter())
 handler.setFormatter(logging.Formatter('%(asctime)s %(hostname)s python/%(filename)s: %(message)s', datefmt='%b %d %H:%M:%S'))

--- a/files/send_mail.py
+++ b/files/send_mail.py
@@ -11,11 +11,11 @@ from zimbra_config import get_config
 
 #setting up logger
 import hostnamefilter
-#handler = logging.FileHandler(filename='/var/log/log')
-handler = logging.StreamHandler(sys.stdout)
-handler.addFilter(hostnamefilter.HostnameFilter())
-handler.setFormatter(logging.Formatter('%(asctime)s %(hostname)s python/%(filename)s: %(message)s', datefmt='%b %d %H:%M:%S'))
-handlers = [handler]
+file_handler = logging.FileHandler(filename='/var/log/log')
+#stream_handler = logging.StreamHandler()
+file_handler.addFilter(hostnamefilter.HostnameFilter())
+file_handler.setFormatter(logging.Formatter('%(asctime)s %(hostname)s python/%(filename)s: %(message)s', datefmt='%b %d %H:%M:%S'))
+handlers = [file_handler]
 logging.basicConfig(handlers=handlers, level=logging.INFO)
 
 logging.info("send_mail started!")

--- a/files/send_mail.py
+++ b/files/send_mail.py
@@ -16,6 +16,8 @@ file_handler = logging.FileHandler(filename='/var/log/log')
 file_handler.addFilter(hostnamefilter.HostnameFilter())
 file_handler.setFormatter(logging.Formatter('%(asctime)s %(hostname)s python/%(filename)s: %(message)s', datefmt='%b %d %H:%M:%S'))
 handlers = [file_handler]
+for handler in logging.root.handlers[:]:
+    logging.root.removeHandler(handler)
 logging.basicConfig(handlers=handlers, level=logging.INFO)
 
 logging.info("send_mail started!")

--- a/files/start.sh
+++ b/files/start.sh
@@ -5,4 +5,4 @@ dovecot
 postfix start
 crond
 python3 /srv/zimbraweb/zimbra_milter.py &
-tail -f /var/log/maillog
+tail -f /var/log/log

--- a/files/start.sh
+++ b/files/start.sh
@@ -4,4 +4,5 @@ python3 /srv/zimbraweb/zimbra_config.py
 dovecot
 postfix start
 crond
-python3 /srv/zimbraweb/zimbra_milter.py
+python3 /srv/zimbraweb/zimbra_milter.py &
+tail -f /var/log/maillog

--- a/files/start.sh
+++ b/files/start.sh
@@ -2,7 +2,12 @@
 python3 /srv/zimbraweb/zimbra_config.py
 /tls.sh
 dovecot
+echo "$(date +"%b %d %H:%M:%S") $HOSTNAME start.sh[$$]: Started dovecot."
 postfix start
 crond
+echo "$(date +"%b %d %H:%M:%S") $HOSTNAME start.sh[$$]: Started crond."
 python3 /srv/zimbraweb/zimbra_milter.py &
+sleep 2
+echo "$(date +"%b %d %H:%M:%S") $HOSTNAME start.sh[$$]: ➔ Switching to log output from '/var/log/log'"
+echo "$(date +"%b %d %H:%M:%S") $HOSTNAME start.sh[$$]: System is now operational and ready to receive E-Mails" > /var/log/log
 tail -f /var/log/log

--- a/files/start.sh
+++ b/files/start.sh
@@ -9,5 +9,5 @@ echo "$(date +"%b %d %H:%M:%S") $HOSTNAME start.sh[$$]: Started crond."
 python3 /srv/zimbraweb/zimbra_milter.py &
 sleep 2
 echo "$(date +"%b %d %H:%M:%S") $HOSTNAME start.sh[$$]: ➔ Switching to log output from '/var/log/log'"
-echo "$(date +"%b %d %H:%M:%S") $HOSTNAME start.sh[$$]: System is now operational and ready to receive E-Mails" > /var/log/log
+echo "$(date +"%b %d %H:%M:%S") $HOSTNAME start.sh[$$]: System is now operational and ready to receive E-Mails" >> /var/log/log
 tail -f /var/log/log

--- a/files/tls.sh
+++ b/files/tls.sh
@@ -5,12 +5,15 @@ keyfile=/tls/key.pem
 
 if [ ! -f "$certfile" ]; then
     # generate a self signed certificate (valid for 10 years)
-    openssl req -x509 -newkey rsa:4096 -keyout $keyfile -out $certfile -sha256 -days 3650 -nodes -subj "/CN=$HOSTNAME"
+    echo "$(date +"%b %d %H:%M:%S") $HOSTNAME start.sh/tls.sh[$$]: No certfile found, generating new self-signed cert..."
+    openssl req -x509 -newkey rsa:4096 -keyout $keyfile -out $certfile -sha256 -days 3650 -nodes -subj "/CN=$HOSTNAME" &>/dev/null
+    echo "$(date +"%b %d %H:%M:%S") $HOSTNAME start.sh/tls.sh[$$]: Writing new private key to '$certfile'"
 fi
 
 chmod 600 $certfile
 chmod 600 $keyfile
 
+echo "$(date +"%b %d %H:%M:%S") $HOSTNAME start.sh/tls.sh[$$]: Writing Postfix conf for TLS"
 postconf -e myhostname=$HOSTNAME
 postconf -e "smtpd_tls_cert_file = ${certfile}"
 postconf -e "smtpd_tls_key_file = ${keyfile}"

--- a/files/zimbra_authentication.py
+++ b/files/zimbra_authentication.py
@@ -11,11 +11,13 @@ from zimbra_config import get_config
 
 #setting up logger
 import hostnamefilter
-#handler = logging.FileHandler(filename='/var/log/log')
-handler = logging.StreamHandler(sys.stdout)
+handler = logging.FileHandler(filename='/var/log/log')
+#handler = logging.StreamHandler(sys.stdout)
 handler.addFilter(hostnamefilter.HostnameFilter())
 handler.setFormatter(logging.Formatter('%(asctime)s %(hostname)s python/%(filename)s: %(message)s', datefmt='%b %d %H:%M:%S'))
 handlers = [handler]
+for handler in logging.root.handlers[:]:
+    logging.root.removeHandler(handler)
 logging.basicConfig(handlers=handlers, level=logging.INFO)
 
 CONFIG = get_config()

--- a/files/zimbra_authentication.py
+++ b/files/zimbra_authentication.py
@@ -4,26 +4,21 @@ import os
 import sys
 import pickle
 import logging
-from datetime import datetime
-import platform
+import sys
 
 from zimbraweb import ZimbraUser
 from zimbra_config import get_config
 
-CONFIG = get_config()
-
 #setting up logger
-class HostnameFilter(logging.Filter):
-    hostname = platform.node()
-    def filter(self, record):
-        record.hostname = HostnameFilter.hostname
-        return True
-handler = logging.FileHandler(filename='/var/log/log')
-#handler = logging.StreamHandler(sys.stdout)
-handler.addFilter(HostnameFilter())
+import hostnamefilter
+#handler = logging.FileHandler(filename='/var/log/log')
+handler = logging.StreamHandler(sys.stdout)
+handler.addFilter(hostnamefilter.HostnameFilter())
 handler.setFormatter(logging.Formatter('%(asctime)s %(hostname)s python/%(filename)s: %(message)s', datefmt='%b %d %H:%M:%S'))
 handlers = [handler]
 logging.basicConfig(handlers=handlers, level=logging.INFO)
+
+CONFIG = get_config()
 
 data = os.read(3, 1024).split(b"\x00")
 AUTH_USERNAME = data[0].decode("utf8")

--- a/files/zimbra_authentication.py
+++ b/files/zimbra_authentication.py
@@ -4,15 +4,25 @@ import os
 import sys
 import pickle
 import logging
+from datetime import datetime
+import platform
 
 from zimbraweb import ZimbraUser
 from zimbra_config import get_config
 
 CONFIG = get_config()
 
-#file_handler = logging.FileHandler(filename='/dev/stdout')
-stdout_handler = logging.StreamHandler(sys.stdout)
-handlers = [stdout_handler]
+#setting up logger
+class HostnameFilter(logging.Filter):
+    hostname = platform.node()
+    def filter(self, record):
+        record.hostname = HostnameFilter.hostname
+        return True
+handler = logging.FileHandler(filename='/var/log/python.log')
+#handler = logging.StreamHandler(sys.stdout)
+handler.addFilter(HostnameFilter())
+handler.setFormatter(logging.Formatter('%(asctime)s %(hostname)s python/%(filename)s: %(message)s', datefmt='%b %d %H:%M:%S'))
+handlers = [handler]
 logging.basicConfig(handlers=handlers, level=logging.INFO)
 
 data = os.read(3, 1024).split(b"\x00")

--- a/files/zimbra_authentication.py
+++ b/files/zimbra_authentication.py
@@ -18,7 +18,7 @@ class HostnameFilter(logging.Filter):
     def filter(self, record):
         record.hostname = HostnameFilter.hostname
         return True
-handler = logging.FileHandler(filename='/var/log/python.log')
+handler = logging.FileHandler(filename='/var/log/log')
 #handler = logging.StreamHandler(sys.stdout)
 handler.addFilter(HostnameFilter())
 handler.setFormatter(logging.Formatter('%(asctime)s %(hostname)s python/%(filename)s: %(message)s', datefmt='%b %d %H:%M:%S'))

--- a/files/zimbra_authentication.py
+++ b/files/zimbra_authentication.py
@@ -10,7 +10,10 @@ from zimbra_config import get_config
 
 CONFIG = get_config()
 
-logging.basicConfig(filename='/srv/zimbraweb/logs/authentication.log', level=logging.INFO)
+#file_handler = logging.FileHandler(filename='/dev/stdout')
+stdout_handler = logging.StreamHandler(sys.stdout)
+handlers = [stdout_handler]
+logging.basicConfig(handlers=handlers, level=logging.INFO)
 
 data = os.read(3, 1024).split(b"\x00")
 AUTH_USERNAME = data[0].decode("utf8")

--- a/files/zimbra_config.py
+++ b/files/zimbra_config.py
@@ -4,6 +4,12 @@ import os
 from typing import Dict
 import re
 import sys
+import logging
+
+#file_handler = logging.FileHandler(filename='/dev/stdout')
+stdout_handler = logging.StreamHandler(sys.stdout)
+handlers = [stdout_handler]
+logging.basicConfig(handlers=handlers, level=logging.INFO)
 
 CONF_PATH = "/srv/zimbraweb/mnt/config.json"
 
@@ -17,10 +23,10 @@ DEFAULT_CONIFG = {
 def main():
     if not os.path.isfile(CONF_PATH):
         if os.environ.get('ENVCONFIG') == "true":
-            print("No config file found, creating from ENV.")
+            logging.info("No config file found, creating from ENV.")
             create_config_env()
         else:
-            print("No config file found, creating.")
+            logging.info("No config file found, creating.")
             create_config()
     while not validate_config():
         if os.isatty(0):
@@ -40,22 +46,22 @@ def validate_config() -> bool:
         try:
             config = json.load(f)
         except JSONDecodeError:
-            print("Corrupt config file. (Invalid JSON)")
+            logging.info("Corrupt config file. (Invalid JSON)")
             return False
     if not "zimbra_host" in config:
-        print("Missing zimbra_host parameter")
+        logging.info("Missing zimbra_host parameter")
         return False
     host = re.match(r"https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)", config["zimbra_host"])
     if not host:
-        print("Malformed zimbra_host. You need to include the protocol (http(s)://)!", file=sys.stderr)
+        logging.info("Malformed zimbra_host. You need to include the protocol (http(s)://)!")
 
     if not "email_domain" in config:
-        print("Missing email_domain parameter", file=sys.stderr)
+        logging.info("Missing email_domain parameter")
         return False
     
     email_domain = re.match(r"(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]", config["email_domain"])
     if not email_domain:
-        print("Malformed email_domain. Only include the part after the @ sign.", file=sys.stderr)
+        logging.info("Malformed email_domain. Only include the part after the @ sign.")
         return False
     return True
 
@@ -67,14 +73,10 @@ def create_config():
             else:
                 DEFAULT_CONIFG[key] = input(f"{key} (default: {default}): ")
     else:
-        print("not running interactively, assuming default values.")
+        logging.info("Not running interactively, assuming default values.")
 
     with open(CONF_PATH, "w") as f:
         json.dump(DEFAULT_CONIFG, f, indent=4)
-
-    if not os.path.isdir("/srv/zimbraweb/mnt/logs"):
-        os.mkdir("/srv/zimbraweb/mnt/logs")
-        os.chmod("/srv/zimbraweb/mnt/logs", 0o777)
 
 def create_config_env():
     for key, default in DEFAULT_CONIFG.items():
@@ -83,13 +85,9 @@ def create_config_env():
     with open(CONF_PATH, "w") as f:
         json.dump(DEFAULT_CONIFG, f, indent=4)
 
-    if not os.path.isdir("/srv/zimbraweb/mnt/logs"):
-        os.mkdir("/srv/zimbraweb/mnt/logs")
-        os.chmod("/srv/zimbraweb/mnt/logs", 0o777)
-
 def get_config() -> Dict[str, str]:
     if not validate_config():
-        print("Invalid configuration! Falling back to default values!", file=sys.stderr)
+        logging.info("Invalid configuration! Falling back to default values.")
         return DEFAULT_CONIFG
     with open(CONF_PATH, "r") as f:
             config = json.load(f)

--- a/files/zimbra_config.py
+++ b/files/zimbra_config.py
@@ -52,22 +52,22 @@ def validate_config() -> bool:
         try:
             config = json.load(f)
         except JSONDecodeError:
-            logging.info("Corrupt config file. (Invalid JSON)")
+            logging.warning("Corrupt config file. (Invalid JSON)")
             return False
     if not "zimbra_host" in config:
-        logging.info("Missing zimbra_host parameter")
+        logging.warning("Missing zimbra_host parameter")
         return False
     host = re.match(r"https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)", config["zimbra_host"])
     if not host:
-        logging.info("Malformed zimbra_host. You need to include the protocol (http(s)://)!")
+        logging.warning("Malformed zimbra_host. You need to include the protocol (http(s)://)!")
 
     if not "email_domain" in config:
-        logging.info("Missing email_domain parameter")
+        logging.warning("Missing email_domain parameter")
         return False
     
     email_domain = re.match(r"(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]", config["email_domain"])
     if not email_domain:
-        logging.info("Malformed email_domain. Only include the part after the @ sign.")
+        logging.warning("Malformed email_domain. Only include the part after the @ sign.")
         return False
     return True
 
@@ -93,7 +93,7 @@ def create_config_env():
 
 def get_config() -> Dict[str, str]:
     if not validate_config():
-        logging.info("Invalid configuration! Falling back to default values.")
+        logging.warning("Invalid configuration! Falling back to default values.")
         return DEFAULT_CONIFG
     with open(CONF_PATH, "r") as f:
             config = json.load(f)

--- a/files/zimbra_config.py
+++ b/files/zimbra_config.py
@@ -5,10 +5,19 @@ from typing import Dict
 import re
 import sys
 import logging
+import platform
 
-#file_handler = logging.FileHandler(filename='/dev/stdout')
-stdout_handler = logging.StreamHandler(sys.stdout)
-handlers = [stdout_handler]
+#setting up logger
+class HostnameFilter(logging.Filter):
+    hostname = platform.node()
+    def filter(self, record):
+        record.hostname = HostnameFilter.hostname
+        return True
+handler = logging.FileHandler(filename='/var/log/python.log')
+#handler = logging.StreamHandler(sys.stdout)
+handler.addFilter(HostnameFilter())
+handler.setFormatter(logging.Formatter('%(asctime)s %(hostname)s python/%(filename)s: %(message)s', datefmt='%b %d %H:%M:%S'))
+handlers = [handler]
 logging.basicConfig(handlers=handlers, level=logging.INFO)
 
 CONF_PATH = "/srv/zimbraweb/mnt/config.json"

--- a/files/zimbra_config.py
+++ b/files/zimbra_config.py
@@ -3,19 +3,14 @@ from json.decoder import JSONDecodeError
 import os
 from typing import Dict
 import re
-import sys
 import logging
-import platform
+import sys
 
 #setting up logger
-class HostnameFilter(logging.Filter):
-    hostname = platform.node()
-    def filter(self, record):
-        record.hostname = HostnameFilter.hostname
-        return True
-handler = logging.FileHandler(filename='/var/log/log')
-#handler = logging.StreamHandler(sys.stdout)
-handler.addFilter(HostnameFilter())
+import hostnamefilter
+#handler = logging.FileHandler(filename='/var/log/log')
+handler = logging.StreamHandler(sys.stdout)
+handler.addFilter(hostnamefilter.HostnameFilter())
 handler.setFormatter(logging.Formatter('%(asctime)s %(hostname)s python/%(filename)s: %(message)s', datefmt='%b %d %H:%M:%S'))
 handlers = [handler]
 logging.basicConfig(handlers=handlers, level=logging.INFO)

--- a/files/zimbra_config.py
+++ b/files/zimbra_config.py
@@ -13,6 +13,8 @@ handler = logging.StreamHandler(sys.stdout)
 handler.addFilter(hostnamefilter.HostnameFilter())
 handler.setFormatter(logging.Formatter('%(asctime)s %(hostname)s python/%(filename)s: %(message)s', datefmt='%b %d %H:%M:%S'))
 handlers = [handler]
+for handler in logging.root.handlers[:]:
+    logging.root.removeHandler(handler)
 logging.basicConfig(handlers=handlers, level=logging.INFO)
 
 CONF_PATH = "/srv/zimbraweb/mnt/config.json"

--- a/files/zimbra_config.py
+++ b/files/zimbra_config.py
@@ -13,7 +13,7 @@ class HostnameFilter(logging.Filter):
     def filter(self, record):
         record.hostname = HostnameFilter.hostname
         return True
-handler = logging.FileHandler(filename='/var/log/python.log')
+handler = logging.FileHandler(filename='/var/log/log')
 #handler = logging.StreamHandler(sys.stdout)
 handler.addFilter(HostnameFilter())
 handler.setFormatter(logging.Formatter('%(asctime)s %(hostname)s python/%(filename)s: %(message)s', datefmt='%b %d %H:%M:%S'))

--- a/files/zimbra_milter.py
+++ b/files/zimbra_milter.py
@@ -24,7 +24,7 @@ class HostnameFilter(logging.Filter):
     def filter(self, record):
         record.hostname = HostnameFilter.hostname
         return True
-handler = logging.FileHandler(filename='/var/log/python.log')
+handler = logging.FileHandler(filename='/var/log/log')
 #handler = logging.StreamHandler(sys.stdout)
 handler.addFilter(HostnameFilter())
 handler.setFormatter(logging.Formatter('%(asctime)s %(hostname)s python/%(filename)s: %(message)s', datefmt='%b %d %H:%M:%S'))

--- a/files/zimbra_milter.py
+++ b/files/zimbra_milter.py
@@ -10,7 +10,6 @@ from io import BytesIO
 import tempfile
 from time import strftime
 import logging
-import platform
 
 import Milter
 from Milter import milter
@@ -19,14 +18,10 @@ from zimbraweb import emlparsing
 from zimbra_config import get_config
 
 #setting up logger
-class HostnameFilter(logging.Filter):
-    hostname = platform.node()
-    def filter(self, record):
-        record.hostname = HostnameFilter.hostname
-        return True
-handler = logging.FileHandler(filename='/var/log/log')
-#handler = logging.StreamHandler(sys.stdout)
-handler.addFilter(HostnameFilter())
+import hostnamefilter
+#handler = logging.FileHandler(filename='/var/log/log')
+handler = logging.StreamHandler(sys.stdout)
+handler.addFilter(hostnamefilter.HostnameFilter())
 handler.setFormatter(logging.Formatter('%(asctime)s %(hostname)s python/%(filename)s: %(message)s', datefmt='%b %d %H:%M:%S'))
 handlers = [handler]
 logging.basicConfig(handlers=handlers, level=logging.INFO)

--- a/files/zimbra_milter.py
+++ b/files/zimbra_milter.py
@@ -10,6 +10,7 @@ from io import BytesIO
 import tempfile
 from time import strftime
 import logging
+import platform
 
 import Milter
 from Milter import milter
@@ -17,9 +18,17 @@ from Milter import milter
 from zimbraweb import emlparsing
 from zimbra_config import get_config
 
-#file_handler = logging.FileHandler(filename='/var/log/milterpy')
-stdout_handler = logging.StreamHandler(sys.stdout)
-handlers = [stdout_handler]
+#setting up logger
+class HostnameFilter(logging.Filter):
+    hostname = platform.node()
+    def filter(self, record):
+        record.hostname = HostnameFilter.hostname
+        return True
+handler = logging.FileHandler(filename='/var/log/python.log')
+#handler = logging.StreamHandler(sys.stdout)
+handler.addFilter(HostnameFilter())
+handler.setFormatter(logging.Formatter('%(asctime)s %(hostname)s python/%(filename)s: %(message)s', datefmt='%b %d %H:%M:%S'))
+handlers = [handler]
 logging.basicConfig(handlers=handlers, level=logging.INFO)
 
 CONFIG = get_config()

--- a/files/zimbra_milter.py
+++ b/files/zimbra_milter.py
@@ -17,11 +17,9 @@ from Milter import milter
 from zimbraweb import emlparsing
 from zimbra_config import get_config
 
-# syslog.openlog('milter')
-#
-file_handler = logging.FileHandler(filename='/srv/zimbraweb/logs/milter.log')
+#file_handler = logging.FileHandler(filename='/dev/stdout')
 stdout_handler = logging.StreamHandler(sys.stdout)
-handlers = [file_handler, stdout_handler]
+handlers = [stdout_handler]
 logging.basicConfig(handlers=handlers, level=logging.INFO)
 
 CONFIG = get_config()
@@ -106,7 +104,6 @@ class zimbraMilter(Milter.Milter):
         self.fp.seek(0)
 
         raw_eml = self.fp.read().decode("utf8")
-        print(raw_eml)
         if 'From: "Microsoft Outlook" <' in raw_eml:
             # this is a Microsoft Outlook Test message, we need to allow it.
             return Milter.ACCEPT
@@ -124,7 +121,6 @@ class zimbraMilter(Milter.Milter):
         return Milter.ACCEPT
 
     def close(self):
-        sys.stdout.flush()		# make log messages visible
         if self.tempname:
             os.remove(self.tempname)  # remove in case session aborted
         if self.fp:
@@ -189,7 +185,7 @@ def runmilter(name, socketname, timeout=0, rmsock=True):
     milter.opensocket(rmsock)
     start_seq = Milter._seq
 
-    print("Changing chmod of socket to 777")
+    logging.debug("Changing chmod of socket to 777")
     os.chmod(socketname, 0o777)
 
     try:
@@ -207,7 +203,6 @@ if __name__ == "__main__":
     socketname = "/var/spool/postfix/milter.sock"
     Milter.factory = zimbraMilter
     Milter.set_flags(Milter.CHGBODY + Milter.CHGHDRS + Milter.ADDHDRS)
-    sys.stdout.flush()
-    print("Starting the Zimbra Milter")
+    logging.info("Starting the Zimbra Milter")
     runmilter("pythonfilter", socketname, 240)
-    print("Shutting down..")
+    logging.info("Shutting down..")

--- a/files/zimbra_milter.py
+++ b/files/zimbra_milter.py
@@ -17,7 +17,7 @@ from Milter import milter
 from zimbraweb import emlparsing
 from zimbra_config import get_config
 
-#file_handler = logging.FileHandler(filename='/dev/stdout')
+#file_handler = logging.FileHandler(filename='/var/log/milterpy')
 stdout_handler = logging.StreamHandler(sys.stdout)
 handlers = [stdout_handler]
 logging.basicConfig(handlers=handlers, level=logging.INFO)

--- a/files/zimbra_milter.py
+++ b/files/zimbra_milter.py
@@ -19,11 +19,13 @@ from zimbra_config import get_config
 
 #setting up logger
 import hostnamefilter
-#handler = logging.FileHandler(filename='/var/log/log')
-handler = logging.StreamHandler(sys.stdout)
+handler = logging.FileHandler(filename='/var/log/log')
+#handler = logging.StreamHandler(sys.stdout)
 handler.addFilter(hostnamefilter.HostnameFilter())
 handler.setFormatter(logging.Formatter('%(asctime)s %(hostname)s python/%(filename)s: %(message)s', datefmt='%b %d %H:%M:%S'))
 handlers = [handler]
+for handler in logging.root.handlers[:]:
+    logging.root.removeHandler(handler)
 logging.basicConfig(handlers=handlers, level=logging.INFO)
 
 CONFIG = get_config()


### PR DESCRIPTION
This closes #41.

Features:

- Log is now unified in appearance: `date hostname source/process: Logmessage`
- Milter is not exposing Message Content to log
- Postfix log is output to Container
- Log Message, when container is ready to receive Mail